### PR TITLE
Add support for RHEL/CentOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ The module has been tested on the following operating systems. Testing and patch
 * Debian 7.0 (Wheezy)
 * Ubuntu 12.04 (Precise Pangolin)
 * Ubuntu 14.04 (Trusty Tahr)
+* RHEL/Centos 6
 
 [![Build Status](https://travis-ci.org/tohuwabohu/puppet-duplicity.png?branch=master)](https://travis-ci.org/tohuwabohu/puppet-duplicity)
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -46,6 +46,9 @@
 # [*duplicity_log_dir*]
 #   Set the path to the log directory. Every profile will get its own log file.
 #
+# [*duplicity_log_group*]
+#   Set the group that owns the log directory.
+#
 # [*gpg_encryption_keys*]
 #   List of default public keyids used to encrypt the backup.
 #
@@ -92,6 +95,7 @@ class duplicity (
   $duply_archive_install_dir = $duplicity::params::duply_archive_install_dir,
   $duply_executable          = $duplicity::params::duply_executable,
   $duply_log_dir             = $duplicity::params::duply_log_dir,
+  $duply_log_group           = $duplicity::params::duply_log_group,
   $gpg_encryption_keys       = $duplicity::params::gpg_encryption_keys,
   $gpg_signing_key           = $duplicity::params::gpg_signing_key,
   $gpg_passphrase            = $duplicity::params::gpg_passphrase,
@@ -125,6 +129,7 @@ class duplicity (
   validate_absolute_path($duply_archive_install_dir)
   validate_absolute_path($duply_executable)
   validate_absolute_path($duply_log_dir)
+  validate_string($duply_log_group)
 
   class { 'duplicity::install': } ->
   class { 'duplicity::setup': }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -21,6 +21,7 @@ class duplicity::params {
     default => 'duply',
   }
   $duply_package_provider = $::osfamily ? {
+    'redhat' => 'yum',
     'debian' => 'apt',
     default  => 'archive'
   }
@@ -50,6 +51,10 @@ class duplicity::params {
   $duply_private_key_dir = "${duply_key_dir}/private"
   $duply_log_dir = $::osfamily ? {
     default => '/var/log/duply'
+  }
+  $duply_log_group = $::osfamily ? {
+    'redhat' => 'root',
+    default  => 'adm',
   }
 
   $gpg_encryption_keys = []

--- a/manifests/setup.pp
+++ b/manifests/setup.pp
@@ -52,7 +52,7 @@ class duplicity::setup inherits duplicity {
   file { $duplicity::duply_log_dir:
     ensure => directory,
     owner  => 'root',
-    group  => 'adm',
+    group  => $duplicity::duply_log_group,
     mode   => '0640',
   }
 
@@ -65,7 +65,7 @@ class duplicity::setup inherits duplicity {
     missingok    => true,
     create       => true,
     create_owner => 'root',
-    create_group => 'adm',
+    create_group => $duplicity::duplicity_log_group,
     create_mode  => '0640',
     require      => File[$duplicity::duply_log_dir],
   }

--- a/metadata.json
+++ b/metadata.json
@@ -22,6 +22,18 @@
                 "12.04",
                 "14.04"
             ]
+        },
+        {
+            "operatingsystem": "RedHat",
+            "operatingsystemrelease": [
+                "6",
+            ]
+        },
+        {
+            "operatingsystem": "CentOS",
+            "operatingsystemrelease": [
+                "6",
+            ]
         }
     ],
     "dependencies": [

--- a/spec/acceptance/nodesets/centos-6-64.yml
+++ b/spec/acceptance/nodesets/centos-6-64.yml
@@ -1,0 +1,13 @@
+HOSTS:
+  centos-6-x64:
+    roles:
+      - master
+    platform: el-6-x86_64
+    hypervisor: vagrant
+    box: puppetlabs/centos-6.6-64-puppet
+    box_url: https://vagrantcloud.com/puppetlabs/boxes/centos-6.6-64-puppet
+
+CONFIG:
+  log_level: info
+  trace_limit: 100
+  type: git

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -62,6 +62,12 @@ describe 'duplicity' do
     it { should contain_package('duply').with_ensure('installed') }
   end
 
+  describe 'by default on RedHat' do
+    let(:facts) { {:osfamily => 'RedHat'} }
+
+    it { should contain_package('duply').with_ensure('installed') }
+  end
+
   describe 'with duplicity_package_ensure => 1.2.3' do
     let(:params) { {:duplicity_package_ensure => '1.2.3'} }
 


### PR DESCRIPTION
This will add support for RHEL/CentOS.  Spec tests pass, and I'm using this version of the module without issue in my environment, however I'm having trouble getting the beaker tests to run.  When I figure out why beaker hates me, I'll do a separate PR if needed.