### PR TITLE
Fix pre 1.7.1 error (purgeFull vs. purge-full)

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -43,6 +43,11 @@
 #   Set the path of the duply executable used in the cron and exec resources. Furthermore it is used to create a symlink
 #   pointing to the executable when installing the archive from sourceforge.
 #
+# [*duply_version*]
+#   Set the version of the installed duply package in case you are not using the default package of your distribution or 
+#   your version is not automatically detected. If you are using `archive` as `duply_package_provider`, please
+#   specify the version via `duply_archive_version`.
+#
 # [*duply_log_dir*]
 #   Set the path to the log directory. Every profile will get its own log file.
 #
@@ -94,6 +99,7 @@ class duplicity (
   $duply_archive_package_dir = $duplicity::params::duply_archive_package_dir,
   $duply_archive_install_dir = $duplicity::params::duply_archive_install_dir,
   $duply_executable          = undef,
+  $duply_version             = undef,
   $duply_log_dir             = $duplicity::params::duply_log_dir,
   $duply_log_group           = $duplicity::params::duply_log_group,
   $gpg_encryption_keys       = $duplicity::params::gpg_encryption_keys,
@@ -131,6 +137,14 @@ class duplicity (
       default => '/usr/bin/duply'
     },
     default   => $duply_executable,
+  }
+
+  $real_duply_version = empty($duply_version) ? {
+    true => $duply_package_provider ? {
+      archive => $duply_archive_version,
+      default => $duplicity::params::duply_version,
+    },
+    default   => $duply_version,
   }
 
   validate_absolute_path($duply_archive_package_dir)

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -52,6 +52,26 @@ class duplicity::params {
     'redhat' => 'root',
     default  => 'adm',
   }
+  
+  case $::operatingsystem {
+    'Debian': {
+      $duply_version = $::lsbmajdistrelease ? {
+        '7' => '1.5.5.5',
+        '8' => '1.9.1'
+      }
+    }
+    'Ubuntu': {
+      $duply_version = $::lsbdistrelease ? {
+        '12.04' => '1.5.5.4',
+        '14.04' => '1.5.10',
+        '14.10' => '1.8.0',
+        '15.04' => '1.9.1'
+      }
+    }
+    default: {
+      $duply_version = $duply_archive_version
+    }
+  }
 
   $gpg_encryption_keys = []
   $gpg_signing_key = ''

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -55,7 +55,7 @@ class duplicity::params {
     'redhat' => 'root',
     default  => 'adm',
   }
-  
+
   case $::operatingsystem {
     'Debian': {
       $duply_version = $::lsbmajdistrelease ? {
@@ -68,7 +68,9 @@ class duplicity::params {
         '12.04' => '1.5.5.4',
         '14.04' => '1.5.10',
         '14.10' => '1.8.0',
-        '15.04' => '1.9.1'
+        '15.04' => '1.9.1',
+        '15.10' => '1.9.2',
+        '16.04' => '1.11'
       }
     }
     default: {

--- a/manifests/profile.pp
+++ b/manifests/profile.pp
@@ -257,9 +257,16 @@ define duplicity::profile(
     ensure  => present,
   }
 
+  if versioncmp($duplicity::params::duply_version, '1.7.1') < 0 {
+    $cron_command  = "${duplicity::real_duply_executable} ${title} cleanup_backup_purge-full --force >> ${duplicity::duply_log_dir}/${title}.log"
+  }
+  else {
+    $cron_command  = "${duplicity::real_duply_executable} ${title} cleanup_backup_purgeFull --force >> ${duplicity::duply_log_dir}/${title}.log"
+  }
+
   cron { "backup-${title}":
     ensure  => $cron_ensure,
-    command => "${duplicity::real_duply_executable} ${title} cleanup_backup_purgeFull --force >> ${duplicity::duply_log_dir}/${title}.log",
+    command => $cron_command,
     user    => 'root',
     hour    => $cron_hour,
     minute  => $cron_minute,

--- a/manifests/profile.pp
+++ b/manifests/profile.pp
@@ -58,6 +58,12 @@
 # [*cron_minute*]
 #   The minute expression of the cron job.
 #
+# [*duply_executable*]
+#   Set the path of the duply executable .
+#
+# [*duply_version*]
+#   Currently installed duply version.
+#
 # === Authors
 #
 # Martin Meinhold <Martin.Meinhold@gmx.de>
@@ -86,6 +92,8 @@ define duplicity::profile(
   $cron_enabled        = $duplicity::cron_enabled,
   $cron_hour           = undef,
   $cron_minute         = undef,
+  $duply_executable    = $duplicity::real_duply_executable,
+  $duply_version       = $duplicity::real_duply_version,
 ) {
   require duplicity
 
@@ -257,11 +265,11 @@ define duplicity::profile(
     ensure  => present,
   }
 
-  if versioncmp($duplicity::params::duply_version, '1.7.1') < 0 {
-    $cron_command  = "${duplicity::real_duply_executable} ${title} cleanup_backup_purge-full --force >> ${duplicity::duply_log_dir}/${title}.log"
+  if versioncmp($duply_version, '1.7.1') < 0 {
+    $cron_command  = "${duply_executable} ${title} cleanup_backup_purge-full --force >> ${duplicity::duply_log_dir}/${title}.log"
   }
   else {
-    $cron_command  = "${duplicity::real_duply_executable} ${title} cleanup_backup_purgeFull --force >> ${duplicity::duply_log_dir}/${title}.log"
+    $cron_command  = "${duply_executable} ${title} cleanup_backup_purgeFull --force >> ${duplicity::duply_log_dir}/${title}.log"
   }
 
   cron { "backup-${title}":

--- a/spec/defines/profile_spec.rb
+++ b/spec/defines/profile_spec.rb
@@ -306,35 +306,35 @@ describe 'duplicity::profile' do
     end
   end
 
-  describe 'with cron_enabled and duply_executable and duply_version 1.7.1' do
-    let(:params) { {:cron_enabled => true, :duply_version => '1.7.1', :duply_executable => 'duply-executable'} }
+  describe 'with cron_enabled and duply_version 1.7.1' do
+    let(:params) { {:cron_enabled => true, :duply_version => '1.7.1'} }
 
     specify do
       should contain_cron("backup-default").with(
         'ensure'  => 'present',
-	'command' => 'duply-executable default cleanup_backup_purgeFull --force >> /var/log/duply/default.log'
+	'command' => 'duply default cleanup_backup_purgeFull --force >> /var/log/duply/default.log'
       )
     end
   end
 
-  describe 'with cron_enabled and duply_executable and duply_version 1.9.1' do
-    let(:params) { {:cron_enabled => true, :duply_version => '1.9.1', :duply_executable => 'duply-executable'} }
+  describe 'with cron_enabled and duply_version 1.9.1' do
+    let(:params) { {:cron_enabled => true, :duply_version => '1.9.1'} }
 
     specify do
       should contain_cron("backup-default").with(
         'ensure'  => 'present',
-	'command' => 'duply-executable default cleanup_backup_purgeFull --force >> /var/log/duply/default.log'
+	'command' => 'duply default cleanup_backup_purgeFull --force >> /var/log/duply/default.log'
       )
     end
   end
 
-  describe 'with cron_enabled and duply_executable and duply_version 1.6' do
-    let(:params) { {:cron_enabled => true, :duply_version => '1.6', :duply_executable => 'duply-executable'} }
+  describe 'with cron_enabled and duply_version 1.6' do
+    let(:params) { {:cron_enabled => true, :duply_version => '1.6''} }
 
     specify do
       should contain_cron("backup-default").with(
         'ensure'  => 'present',
-	'command' => 'duply-executable default cleanup_backup_purge-full --force >> /var/log/duply/default.log'
+	'command' => 'duply default cleanup_backup_purge-full --force >> /var/log/duply/default.log'
       )
     end
   end

--- a/spec/defines/profile_spec.rb
+++ b/spec/defines/profile_spec.rb
@@ -296,4 +296,37 @@ describe 'duplicity::profile' do
       )
     end
   end
+
+  describe 'with cron_enabled and duply_executable and duply_version 1.7.1' do
+    let(:params) { {:cron_enabled => true, :duply_version => '1.7.1', :duply_executable => 'duply-executable'} }
+
+    specify do
+      should contain_cron("backup-default").with(
+        'ensure'  => 'present',
+	'command' => 'duply-executable default cleanup_backup_purgeFull --force >> /var/log/duply/default.log'
+      )
+    end
+  end
+
+  describe 'with cron_enabled and duply_executable and duply_version 1.9.1' do
+    let(:params) { {:cron_enabled => true, :duply_version => '1.9.1', :duply_executable => 'duply-executable'} }
+
+    specify do
+      should contain_cron("backup-default").with(
+        'ensure'  => 'present',
+	'command' => 'duply-executable default cleanup_backup_purgeFull --force >> /var/log/duply/default.log'
+      )
+    end
+  end
+
+  describe 'with cron_enabled and duply_executable and duply_version 1.6' do
+    let(:params) { {:cron_enabled => true, :duply_version => '1.6', :duply_executable => 'duply-executable'} }
+
+    specify do
+      should contain_cron("backup-default").with(
+        'ensure'  => 'present',
+	'command' => 'duply-executable default cleanup_backup_purge-full --force >> /var/log/duply/default.log'
+      )
+    end
+  end
 end

--- a/spec/defines/profile_spec.rb
+++ b/spec/defines/profile_spec.rb
@@ -329,7 +329,7 @@ describe 'duplicity::profile' do
   end
 
   describe 'with cron_enabled and duply_version 1.6' do
-    let(:params) { {:cron_enabled => true, :duply_version => '1.6''} }
+    let(:params) { {:cron_enabled => true, :duply_version => '1.6'} }
 
     specify do
       should contain_cron("backup-default").with(


### PR DESCRIPTION
This adds a duply_version variable which is filled with defaults for Ubuntu and Debian. It is then used to decide on the command in the cron job. This is hopefully not too simple. Has been tested on Debian wheezy and jessie. Should resolve #4 