### PR TITLE
Allow no user and pass to be defined.

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -61,8 +61,8 @@ class duplicity::params {
   $gpg_passphrase = ''
   $gpg_options = []
   $backup_target_url = ''
-  $backup_target_username = ''
-  $backup_target_password = ''
+  $backup_target_username = undef
+  $backup_target_password = undef
 
   $cron_enabled = false
   $exec_path = $::osfamily ? {

--- a/templates/etc/duply/conf.erb
+++ b/templates/etc/duply/conf.erb
@@ -87,8 +87,8 @@ GPG_OPTS='<%= @real_gpg_options.join(' ') %>'
 TARGET='<%= @target %>'
 # optionally the username/password can be defined as extra variables
 # setting them here _and_ in TARGET results in an error
-TARGET_USER='<%= @target_username %>'
-TARGET_PASS='<%= @target_password %>'
+<% if not @target_username %>#<% end %>TARGET_USER='<%= @target_username %>'
+<% if not @target_password %>#<% end %>TARGET_PASS='<%= @target_password %>'
 
 # base directory to backup
 SOURCE='<%= @source %>'


### PR DESCRIPTION
Unbreaks s3 backend when using EC2 instance roles.
