### PR TITLE
Don't exclude files in directory by default.

### DIFF
--- a/manifests/profile.pp
+++ b/manifests/profile.pp
@@ -85,7 +85,7 @@ define duplicity::profile(
   $volsize                = 50,
   $include_filelist       = [],
   $exclude_filelist       = [],
-  $exclude_by_default     = true,
+  $exclude_by_default     = false,
   $cron_enabled           = $duplicity::cron_enabled,
   $cron_hour              = undef,
   $cron_minute            = undef,


### PR DESCRIPTION
I don't understand the reasoning behind excluding all files by default.  Given just a directory path the script should backup the contents of that directory.
