### PR TITLE
Allow configuration of the Duply cache (ARCH_DIR) directory.

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -55,6 +55,12 @@
 # [*duply_log_dir*]
 #   Set the path to the log directory. Every profile will get its own log file.
 #
+# [*duply_cache_dir*]
+#   Defines a folder that holds unencrypted meta data of the backup, enabling new incrementals without the
+#   need to decrypt backend metadata first. If empty or deleted somehow, the private key and it's password are needed.
+#   NOTE: This is confidential data. Put it somewhere safe. It can grow quite big over time so you might want to put 
+#   it not in the home dir. default '~/.cache/duplicity/duply_<profile>/'
+#
 # [*duply_log_group*]
 #   Set the group that owns the log directory.
 #
@@ -110,6 +116,7 @@ class duplicity (
   $duply_archive_executable  = $duplicity::params::duply_archive_executable,
   $duply_log_dir             = $duplicity::params::duply_log_dir,
   $duply_log_group           = $duplicity::params::duply_log_group,
+  $duply_cache_dir           = undef,
   $gpg_encryption_keys       = $duplicity::params::gpg_encryption_keys,
   $gpg_signing_key           = $duplicity::params::gpg_signing_key,
   $gpg_passphrase            = $duplicity::params::gpg_passphrase,
@@ -147,6 +154,9 @@ class duplicity (
   validate_absolute_path($duply_archive_install_dir)
   validate_absolute_path($duply_archive_executable)
   validate_absolute_path($duply_log_dir)
+  if ($duply_cache_dir) {
+    validate_absolute_path($duply_cache_dir)
+  }
   validate_string($duply_log_group)
 
   class { 'duplicity::install': } ->

--- a/manifests/profile.pp
+++ b/manifests/profile.pp
@@ -90,6 +90,7 @@ define duplicity::profile(
   $cron_hour              = undef,
   $cron_minute            = undef,
   $duplicity_extra_params = $duplicity::duplicity_extra_params,
+  $duply_cache_dir        = $duplicity::duply_cache_dir,
 ) {
   require duplicity
 

--- a/templates/etc/duply/conf.erb
+++ b/templates/etc/duply/conf.erb
@@ -158,6 +158,9 @@ DUPL_PARAMS="$DUPL_PARAMS --volsize $VOLSIZE "
 # default '~/.cache/duplicity/duply_<profile>/'
 # if set  '${ARCH_DIR}/<profile>'
 #ARCH_DIR=/some/space/safe/.duply-cache
+<% if @duply_cache_dir -%>
+ARCH_DIR=<%= @duply_cache_dir %>
+<% end %>
 
 # DEPRECATED setting
 # sets duplicity --time-separator option (since v0.4.4.RC2) to allow users 


### PR DESCRIPTION
This PR allows to setup the ARCH_DIR directive.
This is where duplicity stores sensitive information useful to workout each backup delta, etc.
By default is stored in the home directory of calling user (root).
This information grows quickly, into hundreds of megabytes for relatively small backups.
This, in fact, did cause some of our servers to go out of disk space.
I have added the necessary parameters and modified the template so that another directory can be specified, both globally and per profile.
I have renamed the parameter to cache_dir, because on one hand is more representative and on the other puppet-duplicity is already using ARCH to refer to the software package.