### PR TITLE
Add CentOS 6 version number

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -73,6 +73,11 @@ class duplicity::params {
         '16.04' => '1.11'
       }
     }
+    'CentOS': {
+      $duply_version = $::operatingsystemmajrelease ? {
+        '6' => '1.6.0'
+      }
+    }
     default: {
       $duply_version = $duply_archive_version
     }


### PR DESCRIPTION
To fix the purgeFull/purge-full cron issue on CentOS 6 as EPEL repo version of Duply is 1.6.0