### PR TITLE
Implementing custom duply command batch for feature request

### DIFF
--- a/manifests/profile.pp
+++ b/manifests/profile.pp
@@ -68,7 +68,8 @@
 #   An array of extra parameters to pass to duplicity.
 #
 # [*duply_custom_batch*]
-#   Custom batch command for Duply cron job. Batch format is '<command>[[_|+|-]<command>[_|+|-]...]' check Duply man page for details. Leave undefined for default batch: 'cleanup_backup_purgeFull'
+#   Custom batch command for Duply cron job. Batch format is '<command>[[_|+|-]<command>[_|+|-]...]' check Duply man page for details. 
+#   Leave undefined for default batch: 'cleanup_backup_purgeFull'
 #
 # [*exec_before_content*]
 #   Content to be added to the pre-backup script
@@ -337,10 +338,10 @@ define duplicity::profile(
   }
   else {
     if versioncmp($real_duply_version, '1.7.1') < 0 {
-      $duply_batch  = "cleanup_backup_purge-full"
+      $duply_batch  = 'cleanup_backup_purge-full'
     }
     else {
-      $duply_batch  = "cleanup_backup_purgeFull"
+      $duply_batch  = 'cleanup_backup_purgeFull'
     }
   }
 


### PR DESCRIPTION
The following implementation would allow to setup a custom batch command per profile.

It does respect the current functionality of selecting the default duply batch command depending on the installed duply version.

The custom duply batch command can be selected per profile, as some backups may have different requirements than others. For example backups of LVM volums may require critical pre-backup operation such as creating a shapshot and mounting the volume. While filesystem backups might be much more straight forward.