### PR TITLE
Set TARGET_USER only if it's a non-empty string

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "tohuwabohu-duplicity",
-  "version": "4.3.0",
+  "version": "4.3.1",
   "author": "Martin Meinhold",
   "license": "Apache-2.0",
   "summary": "Install and manage duplicity",

--- a/spec/defines/profile_spec.rb
+++ b/spec/defines/profile_spec.rb
@@ -220,7 +220,7 @@ describe 'duplicity::profile' do
     it { should contain_file(default_config_file).with_content(/^TARGET_USER='johndoe'$/) }
   end
 
-  describe 'with target_username => johndoe' and 'with target_password => secret' do
+  describe 'with target_username => johndoe, target_password => secret' do
     let(:params) { {:target_username => 'johndoe', :target_password => 'secret'} }
 
     it { should contain_file(default_config_file).with_content(/^TARGET_USER='johndoe'$/) }

--- a/templates/etc/duply/conf.erb
+++ b/templates/etc/duply/conf.erb
@@ -87,8 +87,10 @@ GPG_OPTS='<%= @real_gpg_options.join(' ') %>'
 TARGET='<%= @target %>'
 # optionally the username/password can be defined as extra variables
 # setting them here _and_ in TARGET results in an error
+<% if @target_username != '' -%>
 TARGET_USER='<%= @target_username %>'
 TARGET_PASS='<%= @target_password %>'
+<% end -%>
 
 # base directory to backup
 SOURCE='<%= @source %>'


### PR DESCRIPTION
Avoid to set TARGET_USER and TARGET_PASS to empty strings if they are not set.
Duply check if these vaules are set and in that case it will add "@TARGET_USER:TARGET_PASS" to the TARGET url, causing an error if they are empty strings.