### PR TITLE
add option to make use of yo61/logrotate module optional

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -75,7 +75,7 @@
 # [*duply_log_group*]
 #   Set the group that owns the log directory.
 #
-# [*duply_use_yo61_log_module*]
+# [*duply_use_logrotate_module*]
 #   Set if yo61/logrotate module is used or logrotate file created by puppet template.
 #
 # [*gpg_encryption_keys*]
@@ -135,7 +135,7 @@ class duplicity (
   $duply_purge_config_dir    = $duplicity::params::duply_purge_config_dir,
   $duply_purge_key_dir       = $duplicity::params::duply_purge_key_dir,
   $duply_environment         = undef,
-  $duply_use_yo61_log_module = $duplicity::params::duply_use_yo61_log_module,
+  $duply_use_logrotate_module = $duplicity::params::duply_use_logrotate_module,
   $gpg_encryption_keys       = $duplicity::params::gpg_encryption_keys,
   $gpg_signing_key           = $duplicity::params::gpg_signing_key,
   $gpg_passphrase            = $duplicity::params::gpg_passphrase,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -76,7 +76,7 @@
 #   Set the group that owns the log directory.
 #
 # [*duply_use_logrotate_module*]
-#   Set if yo61/logrotate module is used or logrotate file created by puppet template.
+#   Set if yo61/logrotate module is used or logrotate file is created by puppet template.
 #
 # [*gpg_encryption_keys*]
 #   List of default public keyids used to encrypt the backup.
@@ -135,7 +135,7 @@ class duplicity (
   $duply_purge_config_dir    = $duplicity::params::duply_purge_config_dir,
   $duply_purge_key_dir       = $duplicity::params::duply_purge_key_dir,
   $duply_environment         = undef,
-  $duply_use_logrotate_module = $duplicity::params::duply_use_logrotate_module,
+  $duply_use_logrotate_module= $duplicity::params::duply_use_logrotate_module,
   $gpg_encryption_keys       = $duplicity::params::gpg_encryption_keys,
   $gpg_signing_key           = $duplicity::params::gpg_signing_key,
   $gpg_passphrase            = $duplicity::params::gpg_passphrase,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -75,6 +75,9 @@
 # [*duply_log_group*]
 #   Set the group that owns the log directory.
 #
+# [*duply_use_yo61_log_module*]
+#   Set if yo61/logrotate module is used or logrotate file created by puppet template.
+#
 # [*gpg_encryption_keys*]
 #   List of default public keyids used to encrypt the backup.
 #

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -132,6 +132,7 @@ class duplicity (
   $duply_purge_config_dir    = $duplicity::params::duply_purge_config_dir,
   $duply_purge_key_dir       = $duplicity::params::duply_purge_key_dir,
   $duply_environment         = undef,
+  $duply_use_yo61_log_module = $duplicity::params::duply_use_yo61_log_module,
   $gpg_encryption_keys       = $duplicity::params::gpg_encryption_keys,
   $gpg_signing_key           = $duplicity::params::gpg_signing_key,
   $gpg_passphrase            = $duplicity::params::gpg_passphrase,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -50,6 +50,7 @@ class duplicity::params {
   $duply_public_key_dir = "${duply_key_dir}/public"
   $duply_private_key_dir = "${duply_key_dir}/private"
   $duply_purge_key_dir = true
+  $duply_use_yo61_log_module = true
   $duply_log_dir = $::osfamily ? {
     default => '/var/log/duply'
   }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -50,7 +50,7 @@ class duplicity::params {
   $duply_public_key_dir = "${duply_key_dir}/public"
   $duply_private_key_dir = "${duply_key_dir}/private"
   $duply_purge_key_dir = true
-  $duply_use_yo61_log_module = true
+  $duply_use_logrotate_module = true
   $duply_log_dir = $::osfamily ? {
     default => '/var/log/duply'
   }

--- a/manifests/setup.pp
+++ b/manifests/setup.pp
@@ -56,7 +56,7 @@ class duplicity::setup inherits duplicity {
     mode   => '0640',
   }
 
-  if $duply_use_logrotate_module == true {
+  if $duplicity::duply_use_logrotate_module == true {
     logrotate::rule { 'duply':
       ensure       => present,
       path         => "${duplicity::duply_log_dir}/*.log",

--- a/manifests/setup.pp
+++ b/manifests/setup.pp
@@ -56,7 +56,7 @@ class duplicity::setup inherits duplicity {
     mode   => '0640',
   }
 
-  if $duply_use_yo61_log_module == true {
+  if $duply_use_logrotate_module == true {
     logrotate::rule { 'duply':
       ensure       => present,
       path         => "${duplicity::duply_log_dir}/*.log",

--- a/manifests/setup.pp
+++ b/manifests/setup.pp
@@ -56,17 +56,29 @@ class duplicity::setup inherits duplicity {
     mode   => '0640',
   }
 
-  logrotate::rule { 'duply':
-    ensure       => present,
-    path         => "${duplicity::duply_log_dir}/*.log",
-    rotate       => 5,
-    size         => '100k',
-    compress     => true,
-    missingok    => true,
-    create       => true,
-    create_owner => 'root',
-    create_group => $duplicity::duply_log_group,
-    create_mode  => '0640',
-    require      => File[$duplicity::duply_log_dir],
+  if $duply_use_yo61_log_module == true {
+    logrotate::rule { 'duply':
+      ensure       => present,
+      path         => "${duplicity::duply_log_dir}/*.log",
+      rotate       => 5,
+      size         => '100k',
+      compress     => true,
+      missingok    => true,
+      create       => true,
+      create_owner => 'root',
+      create_group => $duplicity::duply_log_group,
+      create_mode  => '0640',
+      require      => File[$duplicity::duply_log_dir],
+    }
   }
+  else {
+    file { '/etc/logrotate.d/duply':
+      ensure  => file,
+      owner   => 'root',
+      group   => 'root',
+      mode    => '0640',
+      content => template('duplicity/etc/logrotate.d/duply.erb'),
+    }
+  }
+
 }

--- a/templates/etc/logrotate.d/duply.erb
+++ b/templates/etc/logrotate.d/duply.erb
@@ -1,0 +1,10 @@
+# managed by puppet module duplicity
+# do not change or changes will be overwritten!
+
+<%= scope['duplicity::duply_log_dir'] %>/*.log {
+  compress
+  create 0640 root <%= scope['duplicity::duply_log_group'] %>
+  missingok
+  rotate 5
+  size 100k
+}


### PR DESCRIPTION
yo61/logrotate is not compatible to Ubuntu 16.04 and messes up logrotate in a way where it does not run anymore.

Errors are like: 
`error: skipping "/var/log/apport.log" because parent directory has insecure permissions (It's world writable or writable by group which is not "root") Set "su" directive in config file to tell logrotate which user/group should be used for rotation.`

Added option to params to not use this module and add the logrotate duply file to logrotate.d dir via a file resource instead.

