### PR TITLE
Fix profile folder default permissions

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -66,6 +66,10 @@
 #   NOTE: This is confidential data. Put it somewhere safe. It can grow quite big over time so you might want to put
 #   it not in the home dir. default '~/.cache/duplicity/duply_<profile>/'
 #
+# [*duply_config_dir_mode*]
+#   Set the mode for duply configuration folder '/etc/duply'. This is a file mode, puppet will add +x for directories
+#   automatically. default '0600'
+#
 # [*duply_purge_config_dir*]
 #   Set the purge behaviour for duply configuration folder '/etc/duply'. default 'true'
 #
@@ -132,6 +136,7 @@ class duplicity (
   $duply_log_dir             = $duplicity::params::duply_log_dir,
   $duply_log_group           = $duplicity::params::duply_log_group,
   $duply_cache_dir           = undef,
+  $duply_config_dir_mode     = $duplicity::params::duply_config_dir_mode,
   $duply_purge_config_dir    = $duplicity::params::duply_purge_config_dir,
   $duply_purge_key_dir       = $duplicity::params::duply_purge_key_dir,
   $duply_environment         = undef,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -191,6 +191,6 @@ class duplicity (
   }
   validate_string($duply_log_group)
 
-  class { 'duplicity::install': } ->
-  class { 'duplicity::setup': }
+  class { 'duplicity::install': }
+  -> class { 'duplicity::setup': }
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -39,6 +39,7 @@ class duplicity::params {
   $duply_config_dir = $::osfamily ? {
     default => '/etc/duply'
   }
+  $duply_config_dir_mode = '0600'
   $duply_purge_config_dir = true
   $duply_profile_config_name = 'conf'
   $duply_profile_filelist_name = 'exclude'

--- a/manifests/setup.pp
+++ b/manifests/setup.pp
@@ -17,7 +17,7 @@ class duplicity::setup inherits duplicity {
     ensure  => directory,
     owner   => 'root',
     group   => 'root',
-    mode    => '0644',
+    mode    => $duplicity::duply_config_dir_mode,
     backup  => false,
     purge   => $duplicity::duply_purge_config_dir,
     force   => true,

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -25,7 +25,7 @@ describe 'duplicity' do
         'ensure' => 'directory',
         'owner'  => 'root',
         'group'  => 'root',
-        'mode'   => '0644'
+        'mode'   => '0600'
       )
     }
     it {


### PR DESCRIPTION
Fixes insecure default permissions on duply profile dir and makes them
configurable.
This caused the following message in duply logs :
```
The profile's folder '/etc/duply/<profile_name>' permissions are not
safe (drwxr-xr-x). Secure them now. - (OK)
```