### PR TITLE
Do not ensure absent python-paramiko

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -58,9 +58,11 @@ class duplicity::install inherits duplicity {
       provider => $duplicity::duply_package_provider,
       require  => Package['python-paramiko'],
     }
-    package { 'python-paramiko':
-      ensure   => $duplicity::duply_package_ensure,
-    }
+    # Note (arnaudmorin): we cannot ensure pyton-paramiko $duplicity::duply_package_ensure as
+    # it can break if the package is already ensure present somewhere else in another module.
+    ensure_resource ( 'package', 'python-paramiko', {
+      ensure   => present,
+    })
 
     # If duply was previously installed from archive, it should not pollute the PATH any more ...
     file { $duplicity::duply_archive_executable:

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -60,7 +60,7 @@ class duplicity::install inherits duplicity {
     }
     # Note (arnaudmorin): we cannot ensure pyton-paramiko $duplicity::duply_package_ensure as
     # it can break if the package is already ensure present somewhere else in another module.
-    ensure_resource ( 'package', 'python-paramiko', {
+    ensure_packages ( ['python-paramiko'], {
       ensure   => present,
     })
 


### PR DESCRIPTION
Package python-paramiko can be installed by other modules, so we must use ensure_resource instead of package resource directly.
Also, we don't want to remove that package if we remove duply because it may be used by some other modules / packages on the system.
Best would be to ask duply package maintainer to add the python-paramiko as dependency and avoid such workarounds in the puppet code itself (but bug is still opened on launchpad: https://bugs.launchpad.net/ubuntu/+source/duplicity/+bug/1169463).