### PR TITLE
add lsbmajdistrelease case for Debian 9 stretch

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -64,7 +64,8 @@ class duplicity::params {
     'Debian': {
       $duply_version = $::lsbmajdistrelease ? {
         '7' => '1.5.5.5',
-        '8' => '1.9.1'
+        '8' => '1.9.1',
+        '9' => '1.11.3'
       }
     }
     'Ubuntu': {


### PR DESCRIPTION
I set the archive version to 1.11.3 as this is the version that ships with stretch. Wasn't sure if I should include a default as well.