### PR TITLE
Helper class to be able to create profiles through Foreman

### DIFF
--- a/manifests/profiles.pp
+++ b/manifests/profiles.pp
@@ -1,0 +1,22 @@
+# == Class: duplicity::profiles
+#
+# Configure profiles from a hash.
+#
+# === Parameters
+#
+# [*profiles*]
+#   A hash with profiles to create through duplicity::profile
+# === Authors
+#
+# Jochem van Dieten <jochem@vandieten.net>
+#
+# === Copyright
+#
+# Copyright 2017 Jochem van Dieten
+#
+class duplicity::profiles(
+  $profiles                 = {},
+) {
+  include ::duplicity
+  create_resources('duplicity::profile', $profiles)
+}


### PR DESCRIPTION
Foreman is a management tool which integrates with puppet as an ENC. It can import classes for management through a web interface, but not defined resources, so it can not import duplicity::profile. I added a little helper class that can be imported in Foreman to make it easier to create profiles without writing code.