### PR TITLE
Add profile parameter to specifiy include/exclude in verbatim

### DIFF
--- a/manifests/profile.pp
+++ b/manifests/profile.pp
@@ -46,6 +46,9 @@
 # [*exclude_filelist*]
 #   List of files to be excluded from the backup. Paths can be relative like '**/cache'.
 #
+# [*exclude_content*]
+#   Raw content to set as the exclude file list. See 'man 1 duplicity', section 'FILE SELECTION'.
+#
 # [*exclude_by_default*]
 #   Exclude any file relative to the source directory that is not included; sets the '- **' parameter.
 #
@@ -120,6 +123,7 @@ define duplicity::profile(
   $volsize                = 50,
   $include_filelist       = [],
   $exclude_filelist       = [],
+  $exclude_content        = undef,
   $exclude_by_default     = true,
   $cron_enabled           = $duplicity::cron_enabled,
   $cron_hour              = undef,
@@ -171,6 +175,18 @@ define duplicity::profile(
 
   if !is_array($exclude_filelist) {
     fail("Duplicity::Profile[${title}]: exclude_filelist must be an array")
+  }
+
+  if !empty($exclude_content) {
+    validate_string($exclude_content)
+
+    if !empty($exclude_filelist) {
+      fail("Duplicity::Profile[${title}]: exclude_content cannot be used together with exclude_filelist")
+    }
+
+    if !empty($include_filelist) {
+      fail("Duplicity::Profile[${title}]: exclude_content cannot be used together with include_filelist")
+    }
   }
 
   if !is_bool($gpg_encryption) {
@@ -283,6 +299,14 @@ define duplicity::profile(
       target  => $profile_filelist_file,
       content => $profile_include_filelist,
       order   => '50',
+    }
+  }
+
+  if !empty($exclude_content) {
+    concat::fragment { "${profile_filelist_file}/content":
+      target  => $profile_filelist_file,
+      content => $exclude_content,
+      order   => '70',
     }
   }
 

--- a/spec/defines/profile_spec.rb
+++ b/spec/defines/profile_spec.rb
@@ -302,6 +302,36 @@ describe 'duplicity::profile' do
     }
   end
 
+  describe 'with exclude_content => "+ /etc/duply\n- /etc\n"' do
+    let(:params) { { :exclude_content => "+ /etc/duply\n- /etc\n" } }
+
+    it { should contain_concat__fragment("#{default_filelist}/content").with_content("+ /etc/duply\n- /etc\n") }
+    it { should_not contain_concat__fragment("#{default_filelist}/include") }
+    it { should_not contain_concat__fragment("#{default_filelist}/exclude") }
+  end
+
+  describe 'with exclude_content and exclude_filelist' do
+    let(:params) { {
+        :exclude_content  => "+ /etc/duply\n- /etc\n",
+        :exclude_filelist => ['/a/b']
+    } }
+
+    specify {
+      expect { should contain_concat__fragment("#{default_filelist}/content") }.to raise_error(Puppet::Error, /exclude_filelist/)
+    }
+  end
+
+  describe 'with exclude_content and include_filelist' do
+    let(:params) { {
+        :exclude_content  => "+ /etc/duply\n- /etc\n",
+        :include_filelist => ['/a/b']
+    } }
+
+    specify {
+      expect { should contain_concat__fragment("#{default_filelist}/content") }.to raise_error(Puppet::Error, /include_filelist/)
+    }
+  end
+
   describe 'with exclude_by_default => false' do
     let(:params) { {:exclude_by_default => false} }
 


### PR DESCRIPTION
If there are already sources for rsync-style include/exclude specifications, it is hard to adapt them to the plain array style of the `include_filelist` and `exclude_filelist` parameters.

This commit adds the ability to set the content verbatim, while forcing the exclusive use of this feature. It is meant as a power user feature for cases, where the include/exclude specification is of a more complex nature.
