### PR TITLE
Add default version for Debian and Debian 10 support

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -62,9 +62,11 @@ class duplicity::params {
   case $::operatingsystem {
     'Debian': {
       $duply_version = $::lsbmajdistrelease ? {
-        '7' => '1.5.5.5',
-        '8' => '1.9.1',
-        '9' => '1.11.3'
+        '7'     => '1.5.5.5',
+        '8'     => '1.9.1',
+        '9'     => '1.11.3',
+        '10'    => '2.0.3',
+        default => '1.11.3'
       }
     }
     'Ubuntu': {


### PR DESCRIPTION
Lazy "fix" for providing Debian 10 support.
I choose duply version 2.0.3 since my Debian testing machine provides this version.
Added a default version to prevent Problems with Debian testing (=> facter doesn't always returns an "what i call sane" value in testing).
It "works on my machine".

You may throw this MR in the bin - I thought doing a MR is better then opening an issue.