### PR TITLE
WIP: Distinguish different distributions for paramiko dependency

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -122,6 +122,7 @@ class duplicity (
   String $duply_package_ensure = $duplicity::params::duply_package_ensure,
   String $duply_package_name = $duplicity::params::duply_package_name,
   String $duply_package_provider = $duplicity::params::duply_package_provider,
+  String $duply_paramiko_package_name = $duplicity::params::duply_paramiko_package_name,
   Array[String] $duply_extra_packages = $duplicity::params::duply_extra_packages,
   String $duply_archive_version = $duplicity::params::duply_archive_version,
   String $duply_archive_checksum = $duplicity::params::duply_archive_checksum,

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -57,12 +57,12 @@ class duplicity::install inherits duplicity {
       ensure   => $duplicity::duply_package_ensure,
       name     => $duplicity::duply_package_name,
       provider => $duplicity::duply_package_provider,
-      require  => Package['python-paramiko'],
+      require  => Package[$duplicity::duply_paramiko_package_name],
     }
     # Note (arnaudmorin): we cannot ensure pyton-paramiko $duplicity::duply_package_ensure as
     # it can break if the package is already ensure present somewhere else in another module.
-    ensure_packages ( ['python-paramiko'], {
-      ensure   => present,
+    ensure_packages([$duplicity::duply_paramiko_package_name], {
+      ensure => present,
     })
 
     # If duply was previously installed from archive, it should not pollute the PATH any more ...
@@ -72,5 +72,5 @@ class duplicity::install inherits duplicity {
   }
 
   # Install any additional packages that may be needed by the different backends
-  ensure_packages($duplicity::duply_extra_packages, {'ensure' => 'present'})
+  ensure_packages($duplicity::duply_extra_packages, { 'ensure' => 'present' })
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -20,6 +20,26 @@ class duplicity::params {
     'Debian' => 'apt',
     default  => 'archive'
   }
+
+  if $facts['os']['name'] == 'Ubuntu' {
+    $duply_paramiko_package_name = versioncmp($facts['os']['release']['major'], '20.04') >= 0 ? {
+      true    => 'python3-paramiko',
+      default => 'python-paramiko',
+    }
+  } elsif $facts['os']['name'] == 'Fedora' {
+    $duply_paramiko_package_name = versioncmp($facts['os']['release']['major'], '31') >= 0 ? {
+      true    => 'python3-paramiko',
+      default => 'python2-paramiko',
+    }
+  } elsif $facts['os']['family'] == 'RedHat' {
+    $duply_paramiko_package_name = versioncmp($facts['os']['release']['major'], '8') >= 0 ? {
+      true    => 'python3-paramiko',
+      default => 'python2-paramiko',
+    }
+  } else {
+    $duply_paramiko_package_name = 'python-paramiko'
+  }
+
   $duply_extra_packages = []
   $duply_archive_version = '2.2.2'
   $duply_archive_checksum = '3cf4a2803173726b136b6fe030334bb42045b4d9'
@@ -54,4 +74,5 @@ class duplicity::params {
 
   $cron_enabled = false
   $exec_path = '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin'
+
 }


### PR DESCRIPTION
Different distributions all use different package names for the `python-paramiko` dependency. Sometimes there are multiple such packages, one for Python 2.x and one for Python 3.x. Since this is ultimately used by duplicity itself, the correct version to install is the one for the Python version used by the duplicity installation.

We therefore depend on the Python version that comes with the distribution `duplicity` package.

PS: I'm not very good at Puppet RSpec tests and I did not find any regarding the `python-paramiko` dependency, that I could adapt. Perhaps someone would like to pick up my proposal and add these tests.

PPS: The `Fedora` branches for the `python-paramiko` dependency are a guess from what ever information I could pull from public package repository information. All our Puppet-managed Fedora boxes are currently in Corona home office isolation and not easily reachable. The RHEL ones are also a bit problematic, since they actually depend on EPEL. Should we depend on the `epel-release` package here?