### PR TITLE
Feature request: Allow arrays as valid input for $cron_hour

### DIFF
--- a/manifests/profile.pp
+++ b/manifests/profile.pp
@@ -126,7 +126,7 @@ define duplicity::profile(
   Optional[String] $exclude_content = undef,
   Boolean $exclude_by_default = true,
   Boolean $cron_enabled = $duplicity::cron_enabled,
-  Optional[Variant[Integer, String]] $cron_hour = undef,
+  Optional[Variant[Integer, String, Array]] $cron_hour = undef,
   Optional[Variant[Integer, String]] $cron_minute = undef,
   Optional[String] $duply_version = undef,
   Array[String] $duply_environment = $duplicity::duply_environment,


### PR DESCRIPTION
The builtin cron define accepts _hour_ as array. Since I want to run a backup cron job multiple times a day I need to be able to set e.g.
```
duplicity::profile { backup:
        full_if_older_than => '7D',
        max_full_backups   => 4,
        cron_hour          => [1, 2, 3],
        cron_minute        => '0',
        gpg_encryption     => false,
}
```