### PR TITLE
Allow forwarding duply logs to logger command

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -51,8 +51,15 @@
 # [*duply_archive_executable*]
 #   Set the symbolic path pointing to the configured duply executable when installing the archive from sourceforge.
 #
-# [*duply_version*]
-#   Deprecated, will be removed in the next major release.
+# [*duply_log_output*]
+#   Defines duply logs output type. Valid values are : "file" and "logger".
+#   "logger" use logger command which forward logs to system logs (syslog, journald...)
+#   Default: "file"
+#
+# [*duply_log_logger_tag*]
+#   Mark  every  line  to be logged with the specified tag.
+#   Default: "duply"
+#   NOTE: Available only if duply_log_output equals "logger"
 #
 # [*duply_log_dir*]
 #   Set the path to the log directory. Every profile will get its own log file.
@@ -131,6 +138,8 @@ class duplicity (
   Stdlib::Absolutepath $duply_archive_install_dir = $duplicity::params::duply_archive_install_dir,
   Optional[String] $duply_version = undef,
   Stdlib::Absolutepath $duply_archive_executable = $duplicity::params::duply_archive_executable,
+  String $duply_log_output = $duplicity::params::duply_log_output,
+  String $duply_log_logger_tag = $duplicity::params::duply_log_logger_tag,
   Stdlib::Absolutepath $duply_log_dir = $duplicity::params::duply_log_dir,
   String $duply_log_group = $duplicity::params::duply_log_group,
   Optional[Stdlib::Absolutepath] $duply_cache_dir = undef,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -51,6 +51,9 @@
 # [*duply_archive_executable*]
 #   Set the symbolic path pointing to the configured duply executable when installing the archive from sourceforge.
 #
+# [*duply_version*]
+#   Deprecated, will be removed in the next major release.
+#
 # [*duply_log_output*]
 #   Defines duply logs output type. Valid values are : "file" and "logger".
 #   "logger" use logger command which forward logs to system logs (syslog, journald...)

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -138,7 +138,7 @@ class duplicity (
   Stdlib::Absolutepath $duply_archive_install_dir = $duplicity::params::duply_archive_install_dir,
   Optional[String] $duply_version = undef,
   Stdlib::Absolutepath $duply_archive_executable = $duplicity::params::duply_archive_executable,
-  String $duply_log_output = $duplicity::params::duply_log_output,
+  Enum['file', 'logger'] $duply_log_output = $duplicity::params::duply_log_output,
   String $duply_log_logger_tag = $duplicity::params::duply_log_logger_tag,
   Stdlib::Absolutepath $duply_log_dir = $duplicity::params::duply_log_dir,
   String $duply_log_group = $duplicity::params::duply_log_group,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -37,6 +37,8 @@ class duplicity::params {
   $duply_public_key_dir = "${duply_key_dir}/public"
   $duply_private_key_dir = "${duply_key_dir}/private"
   $duply_purge_key_dir = true
+  $duply_log_output = "file"
+  $duply_log_logger_tag = "duply"
   $duply_use_logrotate_module = true
   $duply_log_dir = '/var/log/duply'
   $duply_log_group = $facts['os']['family'] ? {

--- a/manifests/profile.pp
+++ b/manifests/profile.pp
@@ -349,7 +349,11 @@ define duplicity::profile(
     $duply_batch  = 'cleanup_backup_purgeFull'
   }
 
-  $duply_command  = "duply ${title} ${duply_batch} --force >> ${duplicity::duply_log_dir}/${title}.log"
+  if "${duplicity::duply_log_output}" == "logger" {
+    $duply_command = "duply ${title} ${duply_batch} --force | logger -t \"${duplicity::duply_log_logger_tag}\""
+  } else {
+    $duply_command = "duply ${title} ${duply_batch} --force >> ${duplicity::duply_log_dir}/${title}.log"
+  }
 
   if $niceness {
     $cron_command = "nice -n ${niceness} ${duply_command}"

--- a/manifests/setup.pp
+++ b/manifests/setup.pp
@@ -49,35 +49,38 @@ class duplicity::setup inherits duplicity {
     mode   => '0600',
   }
 
-  file { $duplicity::duply_log_dir:
-    ensure => 'directory',
-    owner  => 'root',
-    group  => $duplicity::duply_log_group,
-    mode   => '0640',
-  }
+  if $duplicity::duply_log_output == "file" {
 
-  if $duplicity::duply_use_logrotate_module == true {
-    logrotate::rule { 'duply':
-      ensure       => 'present',
-      path         => "${duplicity::duply_log_dir}/*.log",
-      rotate       => 5,
-      size         => '100k',
-      compress     => true,
-      missingok    => true,
-      create       => true,
-      create_owner => 'root',
-      create_group => $duplicity::duply_log_group,
-      create_mode  => '0640',
-      require      => File[$duplicity::duply_log_dir],
+    file { $duplicity::duply_log_dir:
+      ensure => 'directory',
+      owner  => 'root',
+      group  => $duplicity::duply_log_group,
+      mode   => '0640',
     }
-  }
-  else {
-    file { '/etc/logrotate.d/duply':
-      ensure  => file,
-      owner   => 'root',
-      group   => 'root',
-      mode    => '0640',
-      content => template('duplicity/etc/logrotate.d/duply.erb'),
+
+    if $duplicity::duply_use_logrotate_module == true {
+      logrotate::rule { 'duply':
+        ensure       => 'present',
+        path         => "${duplicity::duply_log_dir}/*.log",
+        rotate       => 5,
+        size         => '100k',
+        compress     => true,
+        missingok    => true,
+        create       => true,
+        create_owner => 'root',
+        create_group => $duplicity::duply_log_group,
+        create_mode  => '0640',
+        require      => File[$duplicity::duply_log_dir],
+      }
+    }
+    else {
+      file { '/etc/logrotate.d/duply':
+        ensure  => file,
+        owner   => 'root',
+        group   => 'root',
+        mode    => '0640',
+        content => template('duplicity/etc/logrotate.d/duply.erb'),
+      }
     }
   }
 

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -148,5 +148,13 @@ describe 'duplicity' do
       )
     }
   end
+
+  describe 'with duply_log_output => logger' do
+    let(:params) { {:duply_log_output => "logger",:duply_use_logrotate_module => true} }
+
+    it { should_not contain_file('/var/log/duply') }
+    it { should_not contain_logrotate__rule('duply') }
+  end
+
 end
 

--- a/spec/defines/profile_spec.rb
+++ b/spec/defines/profile_spec.rb
@@ -7,7 +7,8 @@ describe 'duplicity::profile' do
       duplicity::public_key { 'key1': content => 'key1' }
       duplicity::public_key { 'key2': content => 'key2' }
 
-      class { 'duplicity': }
+       class { 'duplicity': }
+
     EOS
   }
 
@@ -395,4 +396,42 @@ describe 'duplicity::profile' do
       )
     end
   end
+
+  describe 'with duply_log_output equals logger and cron_enabled' do
+    let(:pre_condition) { <<-EOS
+          class { 'duplicity':
+            duply_log_output => 'logger',
+          }
+    EOS
+
+    }
+
+    let(:params) { {:cron_enabled => true, :duply_version => '1.9.1'} }
+    specify do
+      should contain_cron("backup-default").with(
+        'ensure'  => 'present',
+        'command' => 'duply default cleanup_backup_purgeFull --force | logger -t "duply"'
+      )
+    end
+  end
+
+  describe 'with cron_enabled and duply_log_output => logger and custom tag ' do
+    let(:pre_condition) { <<-EOS
+          class { 'duplicity':
+            duply_log_output => 'logger',
+            duply_log_logger_tag => 'mybackup',
+          }
+    EOS
+
+    }
+
+    let(:params) { {:cron_enabled => true, :duply_version => '1.9.1'} }
+    specify do
+      should contain_cron("backup-default").with(
+        'ensure'  => 'present',
+        'command' => 'duply default cleanup_backup_purgeFull --force | logger -t "mybackup"'
+      )
+    end
+  end
+
 end

--- a/spec/defines/profile_spec.rb
+++ b/spec/defines/profile_spec.rb
@@ -7,7 +7,7 @@ describe 'duplicity::profile' do
       duplicity::public_key { 'key1': content => 'key1' }
       duplicity::public_key { 'key2': content => 'key2' }
 
-       class { 'duplicity': }
+      class { 'duplicity': }
 
     EOS
   }


### PR DESCRIPTION
By default, duply command forward stdout to a file.
I add a way to forward output to logger command. The logger command write messages to system logs (syslog, journald...).

The default behaviour is to use "file" output for duply logs