### PR TITLE
Added debian bullseye support

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -53,15 +53,21 @@ class duplicity::install inherits duplicity {
     }
   }
   else {
+    if os_version_gte('Debian', '11') or (($os['distro']['id'] == 'debian') and ($os['distro']['codename'] == 'bullseye')){
+        $paramiko = "python3-paramiko"
+    }
+    else {
+        $paramiko = "python-paramiko"
+    }
     package { 'duply':
       ensure   => $duplicity::duply_package_ensure,
       name     => $duplicity::duply_package_name,
       provider => $duplicity::duply_package_provider,
-      require  => Package['python-paramiko'],
+      require  => Package[$paramiko],
     }
     # Note (arnaudmorin): we cannot ensure pyton-paramiko $duplicity::duply_package_ensure as
     # it can break if the package is already ensure present somewhere else in another module.
-    ensure_packages ( ['python-paramiko'], {
+    ensure_packages ( [$paramiko], {
       ensure   => present,
     })
 


### PR DESCRIPTION
Debian bullseye has only python3 on board. Therefore on this debian version python3-paramiko is used. Since bullseye is currently in testing, it has no version number. This is the reason to add the codename check as
well.