### PR TITLE
Replace unencrypted git protocol when cloning fixtures

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -1,19 +1,19 @@
 fixtures:
   repositories:
     archive:
-      repo: "git://github.com/voxpupuli/puppet-archive"
+      repo: "https://github.com/voxpupuli/puppet-archive"
       ref: "v4.6.0"
     concat:
-      repo: "git://github.com/puppetlabs/puppetlabs-concat"
+      repo: "https://github.com/puppetlabs/puppetlabs-concat"
       ref: "v6.4.0"
     cron:
-      repo: "git://github.com/puppetlabs/puppetlabs-cron_core"
+      repo: "https://github.com/puppetlabs/puppetlabs-cron_core"
       ref: "1.0.5"
     logrotate:
-      repo: "git://github.com/voxpupuli/puppet-logrotate"
+      repo: "https://github.com/voxpupuli/puppet-logrotate"
       ref: "v5.0.0"
     stdlib:
-      repo: "git://github.com/puppetlabs/puppetlabs-stdlib"
+      repo: "https://github.com/puppetlabs/puppetlabs-stdlib"
       ref: "v6.6.0"
   symlinks:
     duplicity: "#{source_dir}"


### PR DESCRIPTION
See https://github.blog/2021-09-01-improving-git-protocol-security-github/